### PR TITLE
Implemented merged compression mode. (Fixes issue #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bkp --version
 ## Features
 
 - **Copy or Move:** Backup by copying (default) or moving (`-m`).
-- **Compression:** Create `.tar.gz` archives with `-c` when you want a single compressed backup artifact.
+- **Compression Modes:** Use `-c` for a merged archive by default, or `--compress=separate` to keep one archive per target.
 - **Multiple Targets:** Backup multiple files or directories in one go.
 - **Recursive:** Support for backing up folders with `-r`.
 - **Pattern Exclusions:** Skip matching files or folders with repeatable `-e` glob patterns.

--- a/docs/changlelog.md
+++ b/docs/changlelog.md
@@ -1,5 +1,10 @@
 # Change Logs
 
+## v0.4.0 - April 26, 2026
+### New features
+- Added compression modes: `-c` / `--compress` now defaults to merged archives, while `--compress=separate` preserves the previous one-archive-per-target behavior.
+- Added `-a` / `--archive-name NAME` for naming merged archives when backing up multiple targets.
+
 ## v0.3.0 - April 24, 2026
 ### New features
 - Added repeatable `-e` / `--exclude PATTERN` glob filtering for copy, move, and compressed backups.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,8 @@ bkp [OPTIONS] <path1> [path2] ...
 
 ## Options
 
-- `-c, --compress`: Create a compressed tar.gz backup. Requires `tar` and `gzip` only when used.
+- `-c, --compress[=MODE]`: Create a compressed tar.gz backup. `MODE` can be `merged` (default) or `separate`. Requires `tar` and `gzip` only when used.
+- `-a, --archive-name NAME`: Set the merged archive name. Required when merged compression targets multiple files or directories.
 - `-f, --force`: Overwrite existing backup files or directories.
 - `-s, --symbolic`: Follow symbolic links. By default, errors if a symlink is encountered.
 - `-r, --recursive`: Allow backing up directories.
@@ -29,27 +30,37 @@ bkp [OPTIONS] <path1> [path2] ...
    bkp -c file.txt # Creates file.txt.bkp.tar.gz
    ```
 
-3. **Move and Timestamp:**
+3. **Merged Compressed Backup for Multiple Targets:**
+   ```bash
+   bkp -c -a snapshot file.txt notes.txt # Creates snapshot.bkp.tar.gz containing both files
+   ```
+
+4. **Separate Compressed Backups for Multiple Targets:**
+   ```bash
+   bkp --compress=separate file.txt notes.txt # Creates file.txt.bkp.tar.gz and notes.txt.bkp.tar.gz
+   ```
+
+5. **Move and Timestamp:**
    ```bash
    bkp -mt file.txt # Moves file.txt to file.txt.20231024.bkp
    ```
 
-4. **Recursive Folder Backup:**
+6. **Recursive Folder Backup:**
    ```bash
    bkp -r my_folder # Creates my_folder.bkp
    ```
 
-5. **Follow Symlinks:**
+7. **Follow Symlinks:**
    ```bash
    bkp -s my_link # Backs up the actual file my_link points to.
    ```
 
-6. **Exclude Generated Files:**
+8. **Exclude Generated Files:**
    ```bash
    bkp -r -e '*.o' -e '*.tmp' project
    ```
 
-7. **Exclude a Folder While Moving:**
+9. **Exclude a Folder While Moving:**
    ```bash
    bkp -mr -e node_modules app
    ```

--- a/src/backup.sh
+++ b/src/backup.sh
@@ -14,12 +14,13 @@ readonly VERSION="@@VERSION@@"
 readonly VERSION_PLACEHOLDER="@""@VERSION@""@"
 
 FORCE=false
-COMPRESS=false
+COMPRESS_MODE=""
 FOLLOW_SYMLINKS=false
 RECURSIVE=false
 TIMESTAMP=false
 MOVE=false
 DESTINATION=""
+ARCHIVE_NAME=""
 PATHS=()
 EXCLUDE_PATTERNS=()
 EXCLUDE_MATCH_COUNTS=()
@@ -56,15 +57,20 @@ Usage: ${SCRIPT_NAME} [OPTIONS] <path1> [path2] ...
 
 Options:
   -f, --force            Overwrite existing backup files or directories.
-  -c, --compress         Create a compressed tar.gz backup.
+  -c, --compress[=MODE]  Create a compressed tar.gz backup.
   -s, --symbolic         Follow symbolic links. By default, errors if a symlink is encountered.
   -r, --recursive        Allow backing up directories.
   -t, --timestamp        Add a timestamp to the backup name: <name>.<timestamp>.bkp
   -m, --move             Move the resource instead of copying.
   -d, --destination DIR  Specify a target directory for backups.
+  -a, --archive-name     Set merged archive name. Required for merged compression with multiple targets.
   -e, --exclude PATTERN  Exclude matching files or folders using glob patterns.
   -v, --version          Show version information.
   -h, --help             Show this help message.
+
+Compression modes (--compress[=MODE]):
+  merged                 Store targets in a single archive (default).
+  separate               Create one archive per target.
 EOF
 }
 
@@ -96,6 +102,20 @@ show_version() {
     printf '%s\n' "${resolved_version}"
 }
 
+set_compress_mode() {
+    local mode="$1"
+
+    case "${mode}" in
+        merged|separate)
+            COMPRESS_MODE="${mode}"
+            ;;
+        *)
+            error "Invalid compress mode: ${mode}. Use 'merged' or 'separate'."
+            exit 1
+            ;;
+    esac
+}
+
 parse_short_flags() {
     local flags="$1"
     local index flag
@@ -103,7 +123,7 @@ parse_short_flags() {
     for (( index = 0; index < ${#flags}; index++ )); do
         flag="${flags:index:1}"
         case "${flag}" in
-            c) COMPRESS=true ;;
+            c) COMPRESS_MODE="merged" ;;
             f) FORCE=true ;;
             s) FOLLOW_SYMLINKS=true ;;
             r) RECURSIVE=true ;;
@@ -126,7 +146,11 @@ parse_args() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
             -c|--compress)
-                COMPRESS=true
+                COMPRESS_MODE="merged"
+                shift
+                ;;
+            --compress=*)
+                set_compress_mode "${1#--compress=}"
                 shift
                 ;;
             -f|--force)
@@ -155,6 +179,14 @@ parse_args() {
                     exit 1
                 fi
                 DESTINATION="$2"
+                shift 2
+                ;;
+            -a|--archive-name)
+                if [[ $# -lt 2 || -z "$2" || "$2" == -* ]]; then
+                    error "$1 requires a name."
+                    exit 1
+                fi
+                ARCHIVE_NAME="$2"
                 shift 2
                 ;;
             -e|--exclude)
@@ -228,7 +260,22 @@ validate_args() {
         exit 1
     fi
 
-    if [[ "${COMPRESS}" == "true" ]]; then
+    if [[ -n "${ARCHIVE_NAME}" && -z "${COMPRESS_MODE}" ]]; then
+        error "--archive-name requires merged compression."
+        exit 1
+    fi
+
+    if [[ -n "${ARCHIVE_NAME}" && "${COMPRESS_MODE}" != "merged" ]]; then
+        error "--archive-name can only be used with merged compression."
+        exit 1
+    fi
+
+    if [[ "${COMPRESS_MODE}" == "merged" && ${#PATHS[@]} -gt 1 && -z "${ARCHIVE_NAME}" ]]; then
+        error "Merged compression with multiple targets requires -a or --archive-name."
+        exit 1
+    fi
+
+    if [[ -n "${COMPRESS_MODE}" ]]; then
         validate_compress_dependencies
     fi
 
@@ -408,6 +455,8 @@ write_filtered_archive() {
 
 remove_filtered_source_entries() {
     local target="$1"
+    local source_paths_name="${2:-FILTERED_SOURCE_PATHS}"
+    local -n source_paths="${source_paths_name}"
     local index path
 
     if [[ ! -d "${target}" || -L "${target}" ]]; then
@@ -415,8 +464,8 @@ remove_filtered_source_entries() {
         return 0
     fi
 
-    for (( index = ${#FILTERED_SOURCE_PATHS[@]} - 1; index >= 1; index-- )); do
-        path="${FILTERED_SOURCE_PATHS[index]}"
+    for (( index = ${#source_paths[@]} - 1; index >= 1; index-- )); do
+        path="${source_paths[index]}"
 
         if [[ -d "${path}" && ! -L "${path}" ]]; then
             rmdir --ignore-fail-on-non-empty -- "${path}" 2>/dev/null || true
@@ -437,7 +486,7 @@ run_filtered_backup_operation() {
 
     target_name="$(basename "${target}")"
 
-    if [[ "${COMPRESS}" == "true" ]]; then
+    if [[ -n "${COMPRESS_MODE}" ]]; then
         prepare_destination "${final_dest}"
         write_filtered_archive "${target}" "${final_dest}"
     else
@@ -464,6 +513,48 @@ directory_contains_symlink() {
     return 1
 }
 
+validate_backup_target() {
+    local target="$1"
+
+    if [[ ! -e "${target}" && ! -L "${target}" ]]; then
+        error "Target does not exist: ${target}"
+        return 1
+    fi
+
+    if [[ -d "${target}" && "${RECURSIVE}" == "false" ]]; then
+        error "${target} is a directory. Use -r or --recursive to backup folders."
+        return 1
+    fi
+
+    if [[ "${FOLLOW_SYMLINKS}" == "false" ]]; then
+        if [[ -L "${target}" ]]; then
+            error "${target} is a symbolic link. Use -s or --symbolic to follow."
+            return 1
+        fi
+
+        if [[ -d "${target}" ]] && directory_contains_symlink "${target}"; then
+            error "Directory ${target} contains symbolic links. Use -s or --symbolic to follow."
+            return 1
+        fi
+    fi
+}
+
+validate_filtered_target() {
+    local target="$1"
+
+    build_filtered_entries "${target}"
+
+    if [[ "${FILTERED_ROOT_EXCLUDED}" == "true" ]]; then
+        error "Target ${target} is excluded by the provided patterns."
+        return 1
+    fi
+
+    if [[ -d "${target}" && ${FILTERED_TOTAL_CHILDREN} -gt 0 && ${FILTERED_INCLUDED_CHILDREN} -eq 0 ]]; then
+        error "All entries under ${target} are excluded."
+        return 1
+    fi
+}
+
 build_backup_path() {
     local target="$1"
     local base_name backup_name
@@ -477,7 +568,7 @@ build_backup_path() {
 
     backup_name="${backup_name}.bkp"
 
-    if [[ "${COMPRESS}" == "true" ]]; then
+    if [[ -n "${COMPRESS_MODE}" ]]; then
         backup_name="${backup_name}.tar.gz"
     fi
 
@@ -485,6 +576,26 @@ build_backup_path() {
         printf '%s\n' "${DESTINATION}/${backup_name}"
     else
         printf '%s\n' "$(dirname "${target}")/${backup_name}"
+    fi
+}
+
+build_merged_backup_path() {
+    local archive_name="${ARCHIVE_NAME}"
+
+    if [[ -z "${archive_name}" ]]; then
+        archive_name="$(basename "${PATHS[0]}")"
+    fi
+
+    if [[ "${TIMESTAMP}" == "true" ]]; then
+        archive_name="${archive_name}.$(date +%Y%m%d%H%M%S)"
+    fi
+
+    archive_name="${archive_name}.bkp.tar.gz"
+
+    if [[ -n "${DESTINATION}" ]]; then
+        printf '%s\n' "${DESTINATION}/${archive_name}"
+    else
+        printf '%s\n' "${archive_name}"
     fi
 }
 
@@ -501,6 +612,80 @@ prepare_destination() {
     fi
 
     rm -rf -- "${final_dest}"
+}
+
+backup_merged() {
+    local final_dest
+    local target
+    local target_dir
+    local target_name
+    local move_state_dir=""
+    local list_file
+    local index
+    local -a tar_cmd
+    local -a move_targets=()
+    local -a move_lists=()
+
+    for target in "${PATHS[@]}"; do
+        validate_backup_target "${target}" || return 1
+    done
+
+    final_dest="$(build_merged_backup_path)"
+    tar_cmd=("tar" "-czf" "${final_dest}")
+
+    if [[ "${FOLLOW_SYMLINKS}" == "true" ]]; then
+        tar_cmd+=("--dereference")
+    fi
+
+    if [[ ${#EXCLUDE_PATTERNS[@]} -gt 0 ]]; then
+        tar_cmd+=("--no-recursion")
+
+        if [[ "${MOVE}" == "true" ]]; then
+            move_state_dir="$(create_temp_dir)"
+        fi
+
+        for index in "${!PATHS[@]}"; do
+            target="${PATHS[index]}"
+            validate_filtered_target "${target}" || return 1
+
+            target_dir="$(dirname "${target}")"
+            tar_cmd+=("-C" "${target_dir}")
+            tar_cmd+=("${FILTERED_ENTRIES[@]}")
+
+            if [[ "${MOVE}" == "true" ]]; then
+                list_file="${move_state_dir}/${index}.paths"
+                printf '%s\n' "${FILTERED_SOURCE_PATHS[@]}" > "${list_file}"
+                move_targets+=("${target}")
+                move_lists+=("${list_file}")
+            fi
+        done
+    else
+        for target in "${PATHS[@]}"; do
+            target_dir="$(dirname "${target}")"
+            target_name="$(basename "${target}")"
+            tar_cmd+=("-C" "${target_dir}" "${target_name}")
+        done
+    fi
+
+    prepare_destination "${final_dest}"
+    "${tar_cmd[@]}"
+
+    if [[ "${MOVE}" == "true" ]]; then
+        if [[ ${#EXCLUDE_PATTERNS[@]} -gt 0 ]]; then
+            for index in "${!move_targets[@]}"; do
+                local -a merged_source_paths=()
+                # shellcheck disable=SC2034
+                mapfile -t merged_source_paths < "${move_lists[index]}"
+                remove_filtered_source_entries "${move_targets[index]}" merged_source_paths
+            done
+        else
+            for target in "${PATHS[@]}"; do
+                rm -rf -- "${target}"
+            done
+        fi
+    fi
+
+    echo "Backed up ${#PATHS[@]} target(s) -> ${final_dest}"
 }
 
 run_backup_operation() {
@@ -521,7 +706,7 @@ run_backup_operation() {
 
     prepare_destination "${final_dest}"
 
-    if [[ "${COMPRESS}" == "true" ]]; then
+    if [[ -n "${COMPRESS_MODE}" ]]; then
         target_dir="$(dirname "${target}")"
         target_name="$(basename "${target}")"
 
@@ -555,42 +740,12 @@ backup_path() {
     local target="$1"
     local final_dest
 
-    if [[ ! -e "${target}" && ! -L "${target}" ]]; then
-        error "Target does not exist: ${target}"
-        return 1
-    fi
-
-    if [[ -d "${target}" && "${RECURSIVE}" == "false" ]]; then
-        error "${target} is a directory. Use -r or --recursive to backup folders."
-        return 1
-    fi
-
-    if [[ "${FOLLOW_SYMLINKS}" == "false" ]]; then
-        if [[ -L "${target}" ]]; then
-            error "${target} is a symbolic link. Use -s or --symbolic to follow."
-            return 1
-        fi
-
-        if [[ -d "${target}" ]] && directory_contains_symlink "${target}"; then
-            error "Directory ${target} contains symbolic links. Use -s or --symbolic to follow."
-            return 1
-        fi
-    fi
+    validate_backup_target "${target}" || return 1
 
     final_dest="$(build_backup_path "${target}")"
 
     if [[ ${#EXCLUDE_PATTERNS[@]} -gt 0 ]]; then
-        build_filtered_entries "${target}"
-
-        if [[ "${FILTERED_ROOT_EXCLUDED}" == "true" ]]; then
-            error "Target ${target} is excluded by the provided patterns."
-            return 1
-        fi
-
-        if [[ -d "${target}" && ${FILTERED_TOTAL_CHILDREN} -gt 0 && ${FILTERED_INCLUDED_CHILDREN} -eq 0 ]]; then
-            error "All entries under ${target} are excluded."
-            return 1
-        fi
+        validate_filtered_target "${target}" || return 1
 
         run_filtered_backup_operation "${target}" "${final_dest}"
     else
@@ -605,6 +760,12 @@ main() {
 
     parse_args "$@"
     validate_args
+
+    if [[ "${COMPRESS_MODE}" == "merged" && ( ${#PATHS[@]} -gt 1 || -n "${ARCHIVE_NAME}" ) ]]; then
+        backup_merged
+        show_exclude_warnings
+        return 0
+    fi
 
     for path in "${PATHS[@]}"; do
         backup_path "${path}"

--- a/test/compress-archive-name-errors.sh
+++ b/test/compress-archive-name-errors.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/testlib.bash"
+
+setup_test_env
+
+printf 'alpha\n' > one.txt
+
+if output="$(bash "${BKP_SCRIPT}" -a bundle one.txt 2>&1)"; then
+    echo "FAIL: Expected --archive-name without compression to fail"
+    exit 1
+fi
+
+grep -F -- "--archive-name requires merged compression." <<<"${output}"
+
+if output="$(bash "${BKP_SCRIPT}" --compress=separate -a bundle one.txt 2>&1)"; then
+    echo "FAIL: Expected --archive-name with separate compression to fail"
+    exit 1
+fi
+
+grep -F -- "--archive-name can only be used with merged compression." <<<"${output}"
+
+pass_test "Archive name validation rejects unsupported combinations"

--- a/test/compress-merged-multiple.sh
+++ b/test/compress-merged-multiple.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/testlib.bash"
+
+setup_test_env
+
+printf 'alpha\n' > one.txt
+printf 'beta\n' > two.txt
+
+bash "${BKP_SCRIPT}" -c -a bundle one.txt two.txt
+
+[[ -f bundle.bkp.tar.gz ]]
+grep -Fx 'one.txt' < <(tar tzf bundle.bkp.tar.gz)
+grep -Fx 'two.txt' < <(tar tzf bundle.bkp.tar.gz)
+[[ "$(tar xOzf bundle.bkp.tar.gz one.txt)" == "alpha" ]]
+[[ "$(tar xOzf bundle.bkp.tar.gz two.txt)" == "beta" ]]
+
+pass_test "Merged compression stores multiple targets in one archive"

--- a/test/compress-merged-requires-archive-name.sh
+++ b/test/compress-merged-requires-archive-name.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/testlib.bash"
+
+setup_test_env
+
+printf 'alpha\n' > one.txt
+printf 'beta\n' > two.txt
+
+if output="$(bash "${BKP_SCRIPT}" -c one.txt two.txt 2>&1)"; then
+    echo "FAIL: Expected merged compression without archive name to fail"
+    exit 1
+fi
+
+grep -F "Merged compression with multiple targets requires -a or --archive-name." <<<"${output}"
+[[ ! -e bundle.bkp.tar.gz ]]
+
+pass_test "Merged compression requires archive name for multiple targets"

--- a/test/compress-merged-with-destination.sh
+++ b/test/compress-merged-with-destination.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/testlib.bash"
+
+setup_test_env
+
+mkdir backups
+printf 'alpha\n' > one.txt
+printf 'beta\n' > two.txt
+
+bash "${BKP_SCRIPT}" -c -a bundle -d backups one.txt two.txt
+
+[[ -f backups/bundle.bkp.tar.gz ]]
+grep -Fx 'one.txt' < <(tar tzf backups/bundle.bkp.tar.gz)
+grep -Fx 'two.txt' < <(tar tzf backups/bundle.bkp.tar.gz)
+
+pass_test "Merged compression writes named archive to destination"

--- a/test/compress-merged-with-exclude.sh
+++ b/test/compress-merged-with-exclude.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/testlib.bash"
+
+setup_test_env
+
+mkdir first second
+printf 'keep-one\n' > first/a.txt
+printf 'skip-one\n' > first/a.log
+printf 'keep-two\n' > second/b.txt
+printf 'skip-two\n' > second/b.log
+
+bash "${BKP_SCRIPT}" -c -a bundle -r --exclude '*.log' first second
+
+[[ -f bundle.bkp.tar.gz ]]
+grep -Fx 'first/' < <(tar tzf bundle.bkp.tar.gz)
+grep -Fx 'first/a.txt' < <(tar tzf bundle.bkp.tar.gz)
+grep -Fx 'second/' < <(tar tzf bundle.bkp.tar.gz)
+grep -Fx 'second/b.txt' < <(tar tzf bundle.bkp.tar.gz)
+
+if grep -Fx 'first/a.log' < <(tar tzf bundle.bkp.tar.gz); then
+    echo "FAIL: Expected first/a.log to be excluded from merged archive"
+    exit 1
+fi
+
+if grep -Fx 'second/b.log' < <(tar tzf bundle.bkp.tar.gz); then
+    echo "FAIL: Expected second/b.log to be excluded from merged archive"
+    exit 1
+fi
+
+pass_test "Merged compression respects exclude patterns across targets"

--- a/test/compress-merged-with-move.sh
+++ b/test/compress-merged-with-move.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/testlib.bash"
+
+setup_test_env
+
+printf 'alpha\n' > one.txt
+printf 'beta\n' > two.txt
+
+bash "${BKP_SCRIPT}" -c -a bundle -m one.txt two.txt
+
+[[ ! -e one.txt && ! -e two.txt ]]
+[[ -f bundle.bkp.tar.gz ]]
+grep -Fx 'one.txt' < <(tar tzf bundle.bkp.tar.gz)
+grep -Fx 'two.txt' < <(tar tzf bundle.bkp.tar.gz)
+
+pass_test "Merged compression supports move mode"

--- a/test/compress-merged-with-timestamp.sh
+++ b/test/compress-merged-with-timestamp.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/testlib.bash"
+
+setup_test_env
+
+printf 'alpha\n' > one.txt
+printf 'beta\n' > two.txt
+
+bash "${BKP_SCRIPT}" -c -a bundle -t one.txt two.txt
+
+shopt -s nullglob
+archives=(bundle.*.bkp.tar.gz)
+shopt -u nullglob
+
+[[ ${#archives[@]} -eq 1 ]]
+grep -Fx 'one.txt' < <(tar tzf "${archives[0]}")
+grep -Fx 'two.txt' < <(tar tzf "${archives[0]}")
+
+pass_test "Merged compression supports timestamped archive names"

--- a/test/compress-separate-multiple.sh
+++ b/test/compress-separate-multiple.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/testlib.bash"
+
+setup_test_env
+
+printf 'alpha\n' > one.txt
+printf 'beta\n' > two.txt
+
+bash "${BKP_SCRIPT}" --compress=separate one.txt two.txt
+
+[[ -f one.txt.bkp.tar.gz && -f two.txt.bkp.tar.gz ]]
+[[ "$(tar xOzf one.txt.bkp.tar.gz one.txt)" == "alpha" ]]
+[[ "$(tar xOzf two.txt.bkp.tar.gz two.txt)" == "beta" ]]
+
+pass_test "Separate compression keeps one archive per target"


### PR DESCRIPTION
-c and --compress now default to merged compression, --compress=separate preserves the old one-archive-per-target behavior, and -a / --archive-name names merged archives and is required when merged compression targets multiple inputs. The merged path reuses the same validation rules as the existing flow, so recursive checks, symlink handling, excludes, destination, timestamp, force, and move semantics stay consistent.

I added scenario coverage in test/compress-merged-multiple.sh, test/compress-separate-multiple.sh, test/compress-archive-name-errors.sh, plus the merged destination, timestamp, move, and exclude cases under test. I also updated docs/usage.md, README.md, and docs/changlelog.md.